### PR TITLE
Fix crash when newsInfo.kids is undefined

### DIFF
--- a/hackernews/app/controller/news.js
+++ b/hackernews/app/controller/news.js
@@ -18,7 +18,7 @@ module.exports = app => {
       const id = ctx.params.id;
       const newsInfo = yield ctx.service.hackerNews.getItem(id);
       // get comment parallel
-      const commentList = yield newsInfo.kids.map(id => ctx.service.hackerNews.getItem(id));
+      const commentList = yield (newsInfo.kids || []).map(id => ctx.service.hackerNews.getItem(id));
       yield ctx.render('news/detail.tpl', { item: newsInfo, comments: commentList });
     }
 


### PR DESCRIPTION
Hi there, great work with EggJS!

I tried the example and when I click on a news without comments, I got this error:

![screen shot 2017-02-17 at 14 24 54](https://cloud.githubusercontent.com/assets/904724/23066863/e6139efe-f51c-11e6-9505-cfd87ca33507.png)

My PR fixed this error by ensuring that forcing `newsInfo.kids` to be an array.