### PR TITLE
fix: export class of DefaultConfig

### DIFF
--- a/hackernews-async-ts/app/router.ts
+++ b/hackernews-async-ts/app/router.ts
@@ -1,5 +1,6 @@
 import { Application } from 'egg';
-module.exports = (app: Application) => {
+
+export default (app: Application) => {
   const controller = app.controller;
   app.redirect('/', '/news');
   app.get('/news', controller.news.list);

--- a/hackernews-async-ts/app/service/HackerNews.ts
+++ b/hackernews-async-ts/app/service/HackerNews.ts
@@ -1,9 +1,21 @@
 import { Context, Service } from 'egg';
 
+export interface NewsItem {
+  id: number;
+  score: number;
+  time: number;
+  title: string;
+  type: string;
+  url: string;
+  descendants: number;
+  kids: number[];
+  by: string;
+}
+
 /**
  * HackerNews Api Service
  */
-export default class HackerNews extends Service {
+export class HackerNews extends Service {
   constructor(ctx: Context) {
     super(ctx);
   }
@@ -54,17 +66,7 @@ export default class HackerNews extends Service {
    * query item
    * @param id - itemId
    */
-  public async getItem(id: number): Promise<{
-    id: number;
-    score: number;
-    time: number;
-    title: string;
-    type: string;
-    url: string;
-    descendants: number;
-    kids: number[];
-    by: string;
-  }> {
+  public async getItem(id: number): Promise<NewsItem> {
     return await this.request(`item/${id}.json`);
   }
 
@@ -76,3 +78,5 @@ export default class HackerNews extends Service {
     return await this.request(`user/${id}.json`);
   }
 }
+
+export default HackerNews;

--- a/hackernews-async-ts/config/config.ts
+++ b/hackernews-async-ts/config/config.ts
@@ -5,7 +5,7 @@ import * as path from 'path';
 import 'source-map-support/register';
 import defaultConfig from './defaultConfig';
 
-module.exports = (appInfo: EggAppConfig) => {
+export default (appInfo: EggAppConfig) => {
   const config: any = {};
 
   // should change to your own

--- a/hackernews-async-ts/config/defaultConfig.ts
+++ b/hackernews-async-ts/config/defaultConfig.ts
@@ -1,4 +1,4 @@
-class DefaultConfig {
+export class DefaultConfig {
   news =  {
     pageSize: 30,
     serverUrl: 'https://hacker-news.firebaseio.com/v0',


### PR DESCRIPTION
tsc throw errors when tsconfig.json set "declaration": true

config/defaultConfig.ts(9,1): error TS4082: Default export of the module has or is using private name 'DefaultConfig'.
config/defaultConfig.ts(13,28): error TS4033: Property 'config' of exported interface has or is using private name 'DefaultConfig'.