### PR TITLE
fix: Can't find module ''egg-ts-helper/register'' in windows 10

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ assets-with-umi/config/manifest.json
 .umi
 .umi-production
 dist
+.history

--- a/hackernews-async-ts/package.json
+++ b/hackernews-async-ts/package.json
@@ -34,11 +34,11 @@
   },
   "scripts": {
     "start": "egg-scripts start",
-    "dev": "egg-bin dev -r 'egg-ts-helper/register'",
+    "dev": "egg-bin dev -r egg-ts-helper/register",
     "tsc": "ets && tsc -p tsconfig.json",
     "clean": "ets clean",
     "test": "npm run lint -- --fix && npm run test-local",
-    "test-local": "egg-bin test -r 'egg-ts-helper/register'",
+    "test-local": "egg-bin test -r egg-ts-helper/register",
     "cov": "egg-bin cov",
     "lint": "tslint .",
     "ci": "npm run lint && npm run cov",


### PR DESCRIPTION
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->
My Computer:

| software | version |
|----------|-------:|
| windows 10 | 1709 |
| node.js | 8.11.0 |

update package.json scripts

```bash
> egg-bin dev -r 'egg-ts-helper/register'

Error: Cannot find module ''egg-ts-helper/register''
    at Function.Module._resolveFilename (module.js:547:15)
    at Function.Module._load (module.js:474:25)
    at Module.require (module.js:596:17)
    at Function.Module._preloadModules (module.js:753:12)
    at preloadModules (bootstrap_node.js:472:38)
    at startup (bootstrap_node.js:185:9)
    at bootstrap_node.js:609:3
```

