### PR TITLE
fix-sequelize-ts: SequelizeDatabaseError: Column 'id' in field list is ambiguous

### DIFF
--- a/sequelize-ts/app/model/post.ts
+++ b/sequelize-ts/app/model/post.ts
@@ -5,7 +5,7 @@ import { Application } from 'egg';
 export default function(app: Application) {
   const { STRING, INTEGER, DATE } = app.Sequelize;
 
-  const Post = app.model.define('post', {
+  const Model = app.model.define('post', {
     id: {
       type: INTEGER,
       primaryKey: true,
@@ -18,7 +18,7 @@ export default function(app: Application) {
     updated_at: DATE(6),
   });
 
-  return class extends Post {
+  return class Post extends Model {
     static associate() {
       app.model.Post.belongsTo(app.model.User, { as: 'user', foreignKey: 'user_id' });
     }

--- a/sequelize-ts/app/model/user.ts
+++ b/sequelize-ts/app/model/user.ts
@@ -4,7 +4,7 @@ import { Application } from 'egg';
 
 export default function(app: Application) {
   const { STRING, INTEGER, DATE } = app.Sequelize;
-  const User = app.model.define('user', {
+  const Model = app.model.define('user', {
     id: {
       type: INTEGER,
       primaryKey: true,
@@ -16,7 +16,7 @@ export default function(app: Application) {
     updated_at: DATE(6),
   });
 
-  return class extends User {
+  return class User extends Model {
     static associate() {
       app.model.User.hasMany(app.model.Post, { as: 'posts' });
     }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->

Current sequelize-ts example can't not pass all test cases, it will raise error while using 'include' operator. 

Here is the error log:
```
SequelizeDatabaseError: Column 'id' in field list is ambiguous
```

The reason is the sql generated by sequelize was missing the mainTable name, here is the incorrect sql code:
```
SELECT ``.`id`, ``.`title`, ``.`content`, ``.`user_id`, ``.`created_at`, ``.`updated_at`, ``.`created_at` AS `createdAt`, ``.`updated_at` AS `updatedAt`, ``.`user_id` AS `userId`, `user`.`id` AS `user.id`, `user`.`name` AS `user.name`, `user`.`age` AS `user.age` FROM `posts` AS `` LEFT OUTER JOIN `users` AS `user` ON ``.`user_id` = `user`.`id` WHERE ``.`id` = 1;
```

Dig into the source code of sequelize we could find out these lines:
```
// resolve table name options
    if (options.tableAs) {
      mainTable.as = this.quoteIdentifier(options.tableAs);
    } else if (!Array.isArray(mainTable.name) && mainTable.model) {
      mainTable.as = this.quoteIdentifier(mainTable.model.name);
    }
```

In current example, ``` app.model.Post.name ``` will return empty string, because its model return an anonymous class. 
```
return class extends Post { 
   //...
 }
```





